### PR TITLE
[#12] npm-scripts からテスト実行できるように

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,16 @@ $ curl "https://xxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/dev/?android_a
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
 ....
 ```
+
+
+## test
+
+```bash
+$ yarn test
+```
+
+Run only some tests
+
+```bash
+$ $(npm bin)/jest --testNamePattern falsy
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   "transform": {
     "^.+\\.tsx?$": "ts-jest"
   },
-  "testRegex": "spec\\.ts$",
+  "testRegex": "test\\.ts$",
   "moduleFileExtensions": [
     "ts",
     "tsx",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "engines": {
     "node": "~10.15"

--- a/src/android.test.ts
+++ b/src/android.test.ts
@@ -1,5 +1,5 @@
 describe('', () => {
-  it('', () => {
+  it('false is falsy', () => {
     expect(false).toBeFalsy();
   });
 });

--- a/src/android.test.ts
+++ b/src/android.test.ts
@@ -1,0 +1,5 @@
+describe('', () => {
+  it('', () => {
+    expect(false).toBeFalsy();
+  });
+});


### PR DESCRIPTION
resolve #12 

npm-scripts で最低限のテストコードを動かせるようにしました

> "testRegex": "test\\.ts$",

`*.test.ts` といった名前のファイルがテストとして実行されるようになっています