### PR TITLE
[#13] リクエストの query paramter が無いときのエラーをハンドリング

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -6,6 +6,13 @@ import { iosRss } from './src/ios';
 
 export const MobileappReleaseRss: APIGatewayProxyHandler = async (event, _context) => {
   let body = '';
+  if (!event.queryStringParameters) {
+    return {
+      statusCode: 400,
+      body,
+    };
+  }
+
   if (event.queryStringParameters.android_app_id) {
     body = await androidRss(event.queryStringParameters.android_app_id);
   } else if (event.queryStringParameters.ios_app_id) {


### PR DESCRIPTION
Fix #13 

存在しない app_id ( ios, android ) などの処理も実装しようと思ったが、プロジェクト全体の例外設計に関わる気がしたのでスルーしました。